### PR TITLE
Update directories-to-tfrecords.py

### DIFF
--- a/DataToTfRecords/directories-to-tfrecords.py
+++ b/DataToTfRecords/directories-to-tfrecords.py
@@ -75,7 +75,7 @@ def convert_to_tfrecord(dataset_name, data_directory, class_map, segments=1, dir
                 
                 features = {
                     'label': _int64_feature(class_map[label]),
-                    'text_label': _bytes_feature(label),
+                    'text_label': _bytes_feature(label.encode()),
                     'image': _bytes_feature(image_raw)
                 }
                 example = tf.train.Example(features=tf.train.Features(feature=features))


### PR DESCRIPTION
Error:
On Python3 I was receiving an error when trying to convert the labels based on the folders names
TypeError: 'label_name' has type str, but expected one of: bytes

I simply fixed this encoding the label on line 78:
added .encode on line 78 in order to convert labels to bytes.